### PR TITLE
Optimize the rendering of the list when the height is set

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,15 @@ You can track which rows are visible at any given by binding to the `start` and 
 You can rename them with e.g. `bind:start=a bind:end=b`.
 
 
+## `itemHeight`
+
+You can optimize initial display and scrolling when the height of items is known in advance.
+
+```html
+<VirtualList items={things} component={RowComponent} itemHeight={48} />
+```
+
+
 ## Additional properties
 
 You can add arbitrary properties to `<VirtualList>` and they will be forwarded to the rows:

--- a/src/VirtualList.html
+++ b/src/VirtualList.html
@@ -22,7 +22,7 @@
 <script>
 	export default {
 		data() {
-			return { top: 0, bottom: 0, start: 0, end: 0, height: '100%', _props: {} };
+			return { top: 0, bottom: 0, start: 0, end: 0, height: '100%', itemHeight: 0, _props: {} };
 		},
 
 		computed: {
@@ -34,11 +34,11 @@
 		},
 
 		oncreate() {
-			const { items, _props } = this.get();
+			const { items, _props, itemHeight } = this.get();
 			const { viewport, container } = this.refs;
 			const viewportHeight = viewport.offsetHeight;
 
-			const keys = Object.keys(this.options.data).filter(key => key !== 'items' && key !== 'component');
+			const keys = Object.keys(this.options.data).filter(key => key !== 'items' && key !== 'component' && key !== 'itemHeight');
 			if (keys.length) {
 				const state = this.get();
 				keys.forEach(key => {
@@ -58,41 +58,56 @@
 			}
 
 			this.rows = container.getElementsByClassName('row');
-			this.heightMap = [];
 
-			let height = 0;
-			let i = 0;
+			if (itemHeight) {
+				this.heightMap = items.map(item => itemHeight);
+				this.set({
+					end: Math.min(items.length, Math.ceil(viewportHeight / itemHeight)),
+					bottom: items.length * itemHeight
+				});
+			} else {
+				this.heightMap = [];
 
-			while (height < viewportHeight && i < items.length) {
-				this.set({ end: i + 1 });
+				let height = 0;
+				let i = 0;
 
-				const rowHeight = this.heightMap[i] = this.rows[i].offsetHeight;
-				height += rowHeight;
+				while (height < viewportHeight && i < items.length) {
+					this.set({ end: i + 1 });
 
-				i += 1;
+					const rowHeight = this.heightMap[i] = this.rows[i].offsetHeight;
+					height += rowHeight;
+
+					i += 1;
+				}
+
+				const end = i;
+				const avg = Math.round(height / i);
+
+				for (; i < items.length; i += 1) this.heightMap[i] = avg;
+
+				this.set({
+					bottom: (items.length - end) * avg
+				});
 			}
-
-			const end = i;
-			const avg = Math.round(height / i);
-
-			for (; i < items.length; i += 1) this.heightMap[i] = avg;
-
-			this.set({
-				bottom: (items.length - end) * avg
-			});
 		},
 
 		methods: {
 			handleScroll() {
-				const { items, start, end } = this.get();
+				const { items, start, end, itemHeight } = this.get();
 				const { offsetHeight, scrollTop } = this.refs.viewport;
 
 				let paddingTop = 0;
 				let offset = 0;
 				let i = 0;
 
-				for (let v = 0; v < this.rows.length; v += 1) {
-					this.heightMap[start + v] = this.rows[v].offsetHeight;
+				if (itemHeight) {
+					if (this.heightMap.length !== items.length) {
+						this.heightMap = items.map(item => itemHeight);
+					}
+				} else {
+					for (let v = 0; v < this.rows.length; v += 1) {
+						this.heightMap[start + v] = this.rows[v].offsetHeight;
+					}
 				}
 
 				for (; i < items.length; i += 1) {

--- a/test/src/index.js
+++ b/test/src/index.js
@@ -62,6 +62,40 @@ test('allows height to be specified', t => {
 	list.destroy();
 });
 
+test('allows item height to be specified', t => {
+	const Row = svelte.create(`
+		<span>{foo}</span>
+	`);
+
+	const list = new VirtualList({
+		target,
+		data: {
+			items: [{ foo: 'bar' }, { foo: 'bar' }, { foo: 'bar' }, { foo: 'bar' }],
+			component: null,
+			height: '150px',
+			itemHeight: 100
+		}
+	});
+
+	const div = target.firstElementChild;
+
+	t.equal(div.getElementsByClassName('row').length, 2);
+
+	// list.set({ itemHeight: 50 }); // This line throws an error which I believe is in the Svelte framework code:
+	// TypeError: Cannot read property 'length' of undefined
+  //   at getSpreadUpdate (http://localhost:1234/bundle.js:24696:18)
+  //   at Object.update [as p] (http://localhost:1234/bundle.js:25118:36)
+  //   at updateKeyedEach (http://localhost:1234/bundle.js:24624:11)
+  //   at Object.update [as p] (http://localhost:1234/bundle.js:25017:21)
+  //   at VirtualList._set (http://localhost:1234/bundle.js:24814:19)
+	//   at VirtualList.set (http://localhost:1234/bundle.js:24789:8)
+
+	// TODO, run handleScroll when items or itemHeight is updated? Probably not needed.
+	// t.equal(div.getElementsByClassName('row').length, 3);
+
+	list.destroy();
+});
+
 test('props are passed to child component', t => {
 	const Row = svelte.create(`
 		<span>{foo}</span>


### PR DESCRIPTION
Many lists have a set height and can be optimized when that height is provided. An example would be the Explorer in Visual Studio Code which may have hundreds of visible rows all the same height.