### PR TITLE
fix: unmount on destroy invalidating pending tasks

### DIFF
--- a/VirtualList.svelte
+++ b/VirtualList.svelte
@@ -1,5 +1,5 @@
 <script>
-	import { onMount, tick } from 'svelte';
+	import { onMount, tick, onDestroy } from 'svelte';
 
 	// props
 	export let items;
@@ -36,6 +36,7 @@
 		const { scrollTop } = viewport;
 
 		await tick(); // wait until the DOM is up to date
+		if (!mounted) return;
 
 		let content_height = top - scrollTop;
 		let i = start;
@@ -46,6 +47,7 @@
 			if (!row) {
 				end = i + 1;
 				await tick(); // render the newly visible row
+				if (!mounted) return;
 				row = rows[i - start];
 			}
 
@@ -131,6 +133,11 @@
 	onMount(() => {
 		rows = contents.getElementsByTagName('svelte-virtual-list-row');
 		mounted = true;
+	});
+
+	// mark as unmounted for pending tasks
+	onDestroy(() => {
+		mounted = false;
 	});
 </script>
 


### PR DESCRIPTION
I'm working on a proyect where I need to destroy and recreate the svelte-virtual-list in order to reflect some changes. After doing that this error appears on the console:
```js
Uncaught (in promise) TypeError: Cannot read property 'offsetHeight' of undefined
    at refresh
```

It happens that a pending `refresh` is failing after destroying the component, because it awaits for next ticks inside the function, and after those awaits in some moment the component is no longer available.

I prupose to mark `mounted` as `false` when the component is being destroyed so pending task can know it.

Sorry for my english :pray: 