### PR TITLE
Expose index

### DIFF
--- a/VirtualList.svelte
+++ b/VirtualList.svelte
@@ -23,7 +23,9 @@
 	let bottom = 0;
 	let average_height;
 
-	$: visible = items.slice(start, end).map((data, i) => {
+  $: computedItems = items.map((item, index) => ({item, absoluteIndex: index}));
+
+	$: visible = computedItems.slice(start, end).map((data, i) => {
 		return { index: i + start, data };
 	});
 
@@ -161,7 +163,7 @@
 	>
 		{#each visible as row (row.index)}
 			<svelte-virtual-list-row>
-				<slot item={row.data}>Missing template</slot>
+				<slot item={row.data.item} absoluteIndex={row.data.absoluteIndex}>Missing template</slot>
 			</svelte-virtual-list-row>
 		{/each}
 	</svelte-virtual-list-contents>


### PR DESCRIPTION
Relates #37 #40 #18 

Tested on Svelte ^3.46.2 with a list of 1,533 items - it rendered OK, but if folks are troubled by the performance of iterating through the list beforehand, maybe there's some other solution. It could be an option that the user opts in to, for instance.

Use it like this 

```
  <VirtualList items={statements} let:item let:absoluteIndex>
    <Statement {...item} index={absoluteIndex} />
  </VirtualList>
```