### PR TITLE
Index attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,16 @@ You can optimize initial display and scrolling when the height of items is known
 </VirtualList>
 ```
 
+## `index`
+
+You can access the index of each item in the virtual list by using the `index` attribute:
+
+```html
+<VirtualList items={things} let:item let:index>
+  <p>{index}: {item.number} - {item.name}</p>
+</VirtualList>
+```
+
 
 ## Configuring webpack
 

--- a/VirtualList.svelte
+++ b/VirtualList.svelte
@@ -161,7 +161,7 @@
 	>
 		{#each visible as row (row.index)}
 			<svelte-virtual-list-row>
-				<slot item={row.data}>Missing template</slot>
+				<slot item={row.data} index={row.index}>Missing template</slot>
 			</svelte-virtual-list-row>
 		{/each}
 	</svelte-virtual-list-contents>


### PR DESCRIPTION
Fixes #37

Includes `index` access for each item.

Updates docs to include `let:index`